### PR TITLE
fix working with recent setuptools

### DIFF
--- a/setuptools_trial/setuptools_trial.py
+++ b/setuptools_trial/setuptools_trial.py
@@ -39,7 +39,7 @@ class TrialTest(test.test):
                 "You may specify a module or a suite, but not both"
             )
 
-        self.test_args = self.test_suite
+        self.test_args = [self.test_suite]
 
     def run_tests(self):
         # We do the import from Twisted inside the function instead of the top


### PR DESCRIPTION
Looks like `setuptools` expect that `self.test_args` is a list: 
it generates debug message in `test.run()` by appending it to other list:

```
    def run(self):
        ...

        cmd = ' '.join(self._argv)
        if self.dry_run:
            self.announce('skipping "%s" (dry run)' % cmd)
        else:
            self.announce('running "%s"' % cmd)
            self.with_project_on_sys_path(self.run_tests)

...

    @property
    def _argv(self):
        return ['unittest'] + self.test_args
```

which fails with the following exception:

```
Traceback (most recent call last):
  File "setup.py", line 154, in <module>
    setup(**setup_args)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/bob/stuff/buildbot/env-setuptools/local/lib/python2.7/site-packages/setuptools/command/test.py", line 154, in run
    cmd = ' '.join(self._argv)
  File "/home/bob/stuff/buildbot/env-setuptools/local/lib/python2.7/site-packages/setuptools/command/test.py", line 185, in _argv
    return ['unittest'] + self.test_args
TypeError: can only concatenate list (not "str") to list
```

Tested with `setuptools==20.1.1`.
`self.test_args` is converted to list of strings in setuptools_trial's `run_tests()` anyway, so nothing should break.
